### PR TITLE
prettier v2 compatibility

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,7 +8,7 @@
   The above copyright notice and this permission notice shall be
   included in all copies or substantial portions of this Source Code Form.
 */
-const { parsers } = require('prettier/parser-babylon');
+const { parsers } = require('prettier/parser-babel');
 
 const { dependencies } = require('./rules/dependencies');
 const { engines } = require('./rules/engines');

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "lint-staged": "^9.2.0",
     "nyc": "^14.1.0",
     "pre-commit": "^1.2.2",
-    "prettier": "^1.18.2"
+    "prettier": "^2.0"
   },
   "ava": {
     "files": [


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x ([x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] tests
- [ ] documentation
- [ ] metadata

### Breaking Changes?

- [ ] yes
- [ ] no

If yes, please describe the breakage.

### Please Describe Your Changes

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

Prettier v2 [removed the `babylon` parser](https://prettier.io/blog/2020/03/21/2.0.0.html#remove-deprecated-api-and-change-util-signatures-6993httpsgithubcomprettierprettierpull6993-by-fiskerhttpsgithubcomfisker)

Sorry but I don't have the capacity to get involved in how to really make this good and ready to release as a new version of your project, e.g. tests, release management, etc... This PR is just to bring a starting point. Making this change to my local copy of this plugin fixed the runtime error and made the plugin work with prettier v2.